### PR TITLE
Remove tasty-discover auto discovery

### DIFF
--- a/geeklets-hs.cabal
+++ b/geeklets-hs.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 08a6995971c6fad561d3e211ee98789ce34ca7524928643ba012c370c59134f4
+-- hash: fd01a1b40d2d7afa85626b249d8ed50e82a25875184ac8e133c8d174d7d830cc
 
 name:           geeklets-hs
 version:        0.1.0.0
@@ -72,13 +72,13 @@ executable geeklets-exe
 
 test-suite spec
   type: exitcode-stdio-1.0
-  main-is: Driver.hs
+  main-is: Main.hs
   other-modules:
       Bytes.NetworkBytesProp
       Bytes.NetworkBytesSpec
       Network.IP.InternalProp
       Network.Speed.InternalProp
-      PureCLISpec
+      TypesSpec
       Paths_geeklets_hs
   hs-source-dirs:
       test/spec
@@ -91,7 +91,6 @@ test-suite spec
     , process
     , regex-tdfa
     , tasty
-    , tasty-discover
     , tasty-hedgehog
     , tasty-hspec
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -52,7 +52,7 @@ executables:
 
 tests:
   spec:
-    main: Driver.hs
+    main: Main.hs
     source-dirs: test/spec
     ghc-options:
     - -threaded
@@ -63,6 +63,5 @@ tests:
     - hedgehog
     - hspec
     - tasty
-    - tasty-discover
     - tasty-hedgehog
     - tasty-hspec

--- a/test/spec/Bytes/NetworkBytesProp.hs
+++ b/test/spec/Bytes/NetworkBytesProp.hs
@@ -3,89 +3,95 @@
 {-# LANGUAGE NumericUnderscores #-}
 
 module Bytes.NetworkBytesProp
-  ( hprop_normalizes,
+  ( networkBytesProps,
   )
 where
 
 import Bytes.NetworkBytes
-import Hedgehog
+import Hedgehog ((===))
+import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
+import qualified Test.Tasty as T
+import qualified Test.Tasty.Hedgehog as TH
 
-hprop_normalizes :: Property
-hprop_normalizes = property $ do
-  bytes <- forAll genBytes
+networkBytesProps :: T.TestTree
+networkBytesProps = T.testGroup "Bytes.NetworkBytes" [normalizesBytes]
+
+normalizesBytes :: T.TestTree
+normalizesBytes = TH.testProperty "Normalizes bytes" $ H.property $ do
+  bytes <- H.forAll genBytes
   let bytes' = normalize bytes
-  annotateShow bytes'
+  H.annotateShow bytes'
   verifyNormalized bytes bytes'
 
-verifyNormalized :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> AnyByteSz b a -> PropertyT IO ()
+verifyNormalized :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> AnyByteSz b a -> H.PropertyT IO ()
 verifyNormalized bytes (MkAnyByteSz bytes'@(MkB _)) = verifyB bytes bytes'
 verifyNormalized bytes (MkAnyByteSz bytes'@(MkKB _)) = verifyKB bytes bytes'
 verifyNormalized bytes (MkAnyByteSz bytes'@(MkMB _)) = verifyMB bytes bytes'
 verifyNormalized bytes (MkAnyByteSz bytes'@(MkGB _)) = verifyGB bytes bytes'
 verifyNormalized bytes (MkAnyByteSz bytes'@(MkTB _)) = verifyTB bytes bytes'
 
-verifyB :: (Show a, Num a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'B a -> PropertyT IO ()
+verifyB :: (Show a, Num a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'B a -> H.PropertyT IO ()
 verifyB (MkB bytes) (MkB bytes') = do
-  assert $ bytes < 1_000
+  H.assert $ bytes < 1_000
   bytes === bytes'
 
-verifyKB :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'KB a -> PropertyT IO ()
+verifyKB :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'KB a -> H.PropertyT IO ()
 verifyKB (MkB bytes) (MkKB bytes') = do
-  assert $ bytes' < 1_000
-  annotate $ "B: " <> show bytes <> ", KB: " <> show bytes'
+  H.assert $ bytes' < 1_000
+  H.annotate $ "B: " <> show bytes <> ", KB: " <> show bytes'
   eqEpsilon (bytes / 1_000) bytes' 1
 
-verifyMB :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'MB a -> PropertyT IO ()
+verifyMB :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'MB a -> H.PropertyT IO ()
 verifyMB (MkB bytes) (MkMB bytes') = do
-  assert $ bytes' < 1_000
-  annotate $ "B: " <> show bytes <> ", MB: " <> show bytes'
+  H.assert $ bytes' < 1_000
+  H.annotate $ "B: " <> show bytes <> ", MB: " <> show bytes'
   eqEpsilon (bytes / 1_000_000) bytes' 1
 
-verifyGB :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'GB a -> PropertyT IO ()
+verifyGB :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'GB a -> H.PropertyT IO ()
 verifyGB (MkB bytes) (MkGB bytes') = do
-  assert $ bytes' < 1_000
-  annotate $ "B: " <> show bytes <> ", GB: " <> show bytes'
+  H.assert $ bytes' < 1_000
+  H.annotate $ "B: " <> show bytes <> ", GB: " <> show bytes'
   eqEpsilon (bytes / 1_000_000_000) bytes' 1
 
-verifyTB :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'TB a -> PropertyT IO ()
+verifyTB :: (Show a, Fractional a, Ord a) => NetworkBytes b 'B a -> NetworkBytes b 'TB a -> H.PropertyT IO ()
 verifyTB (MkB bytes) (MkTB bytes') = do
-  assert $ bytes' < 1_000
-  annotate $ "B: " <> show bytes <> ", TB: " <> show bytes'
+  H.assert $ bytes' < 1_000
+  H.annotate $ "B: " <> show bytes <> ", TB: " <> show bytes'
   eqEpsilon (bytes / 1_000_000_000_000) bytes' 1
 
-eqEpsilon :: (Show a, Num a, Ord a) => a -> a -> a -> PropertyT IO ()
+eqEpsilon :: (Show a, Num a, Ord a) => a -> a -> a -> H.PropertyT IO ()
 eqEpsilon x y threshold = do
   let d = abs (x - y)
-  footnote $ "Failed: |" <> show x <> " - " <> show y <> "| < " <> show threshold
-  assert $ d < threshold
+  H.footnote $ "Failed: |" <> show x <> " - " <> show y <> "| < " <> show threshold
+  H.assert $ d < threshold
 
-genBytes :: Gen (NetworkBytes 'Down 'B Double)
+genBytes :: H.Gen (NetworkBytes 'Down 'B Double)
 genBytes = do
   Gen.choice [genB, genKB, genMB, genGB, genTB]
 
-genB :: Gen (NetworkBytes 'Down 'B Double)
+genB :: H.Gen (NetworkBytes 'Down 'B Double)
 genB = do
   x <- Gen.integral (Range.constantFrom 500 0 999)
   pure $ MkB (fromInteger x)
 
-genKB :: Gen (NetworkBytes 'Down 'B Double)
+genKB :: H.Gen (NetworkBytes 'Down 'B Double)
 genKB = do
   x <- Gen.integral (Range.constantFrom 500_000 1_000 999_999)
   pure $ MkB (fromInteger x)
 
-genMB :: Gen (NetworkBytes 'Down 'B Double)
+genMB :: H.Gen (NetworkBytes 'Down 'B Double)
 genMB = do
   x <- Gen.integral (Range.constantFrom 500_000_000 1_000_000 999_999_999)
   pure $ MkB (fromInteger x)
 
-genGB :: Gen (NetworkBytes 'Down 'B Double)
+genGB :: H.Gen (NetworkBytes 'Down 'B Double)
 genGB = do
   x <- Gen.integral (Range.constantFrom 500_000_000_000 1_000_000_000 999_999_999_999)
   pure $ MkB (fromInteger x)
 
-genTB :: Gen (NetworkBytes 'Down 'B Double)
+genTB :: H.Gen (NetworkBytes 'Down 'B Double)
 genTB = do
   x <- Gen.integral (Range.constantFrom 500_000_000_000_000 1_000_000_000_000 999_999_999_999_999)
   pure $ MkB (fromInteger x)

--- a/test/spec/Bytes/NetworkBytesSpec.hs
+++ b/test/spec/Bytes/NetworkBytesSpec.hs
@@ -4,16 +4,18 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Bytes.NetworkBytesSpec
-  ( spec_networkBytesSpec,
+  ( networkBytesSpecs,
   )
 where
 
 import Bytes.NetworkBytes
 import Test.Hspec
+import qualified Test.Tasty as T
+import qualified Test.Tasty.Hspec as TH
 
-spec_networkBytesSpec :: Spec
-spec_networkBytesSpec = do
-  describe "Bytes.NetworkBytesSpec" $ do
+networkBytesSpecs :: IO [T.TestTree]
+networkBytesSpecs = TH.testSpecs $ do
+  describe "Bytes.NetworkBytes" $ do
     it "Displays B" $ do
       dispAnyBytes mkB `shouldBe` "5.25 B"
     it "Displays KB" $ do

--- a/test/spec/Driver.hs
+++ b/test/spec/Driver.hs
@@ -1,1 +1,0 @@
-{-# OPTIONS_GHC -F -pgmF tasty-discover #-}

--- a/test/spec/Main.hs
+++ b/test/spec/Main.hs
@@ -1,0 +1,29 @@
+module Main
+  ( main,
+  )
+where
+
+import Bytes.NetworkBytesProp
+import Bytes.NetworkBytesSpec
+import Network.IP.InternalProp
+import Network.Speed.InternalProp
+import qualified Test.Tasty as T
+import TypesSpec
+
+main :: IO ()
+main = specs >>= \s -> T.defaultMain $ T.testGroup "Tests" [props, s]
+
+specs :: IO T.TestTree
+specs =
+  (\t1 t2 -> T.testGroup "HSpec Specs" (t1 <> t2))
+    <$> networkBytesSpecs
+    <*> dslSpec
+
+props :: T.TestTree
+props =
+  T.testGroup
+    "Hedgehog Properties"
+    [ networkBytesProps,
+      networkIpProps,
+      networkSpeedProps
+    ]

--- a/test/spec/Network/IP/InternalProp.hs
+++ b/test/spec/Network/IP/InternalProp.hs
@@ -1,25 +1,32 @@
 {-# LANGUAGE DataKinds #-}
 
 module Network.IP.InternalProp
-  ( hprop_combineIPs,
+  ( networkIpProps,
   )
 where
 
-import Hedgehog
+import Hedgehog ((===))
+import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
-import Network.IP.Internal
 import qualified Hedgehog.Range as Range
+import Network.IP.Internal
+import qualified Test.Tasty as T
+import qualified Test.Tasty.Hedgehog as TH
 
-hprop_combineIPs :: Property
-hprop_combineIPs = property $ do
-  (local@(MkIP l), global@(MkIP g)) <- forAll genIPs
+networkIpProps :: T.TestTree
+networkIpProps = T.testGroup "Network.IP.Internal" [combinedIPsMatch]
+
+combinedIPsMatch :: T.TestTree
+combinedIPsMatch = TH.testProperty "Combines IPs" $ H.property $ do
+  (local@(MkIP l), global@(MkIP g)) <- H.forAll genIPs
   "Local  IP: "
     <> l
     <> "\nGlobal IP: "
     <> g
     === combineIPs local global
 
-genIPs :: Gen (IP 'Local, IP 'Global)
+genIPs :: H.Gen (IP 'Local, IP 'Global)
 genIPs = (,) <$> genIP <*> genIP
-  where genStr = Gen.string (Range.linear 0 100) Gen.ascii
-        genIP = MkIP <$> genStr
+  where
+    genStr = Gen.string (Range.linear 0 100) Gen.ascii
+    genIP = MkIP <$> genStr

--- a/test/spec/Network/Speed/InternalProp.hs
+++ b/test/spec/Network/Speed/InternalProp.hs
@@ -4,27 +4,32 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Network.Speed.InternalProp
-  ( hprop_parseSucceeds,
+  ( networkSpeedProps,
   )
 where
 
-import Hedgehog
+import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import Network.Speed.Internal
+import qualified Test.Tasty as T
 import Types
+import qualified Test.Tasty.Hedgehog as TH
 
-hprop_parseSucceeds :: Property
-hprop_parseSucceeds = property $ do
-  (MkBytesStr {s = s1}, MkBytesStr {s = s2}) <- forAll gen2BytesStr
+networkSpeedProps :: T.TestTree
+networkSpeedProps = T.testGroup "Network.Speed.Internal" [parseSucceeds]
+
+parseSucceeds :: T.TestTree
+parseSucceeds = TH.testProperty "Parse succeeds" $ H.property $ do
+  (MkBytesStr {s = s1}, MkBytesStr {s = s2}) <- H.forAll gen2BytesStr
   let res = parseAndDisplayDiff s1 s2
-  assert $ isRSuccess res
+  H.assert $ isRSuccess res
 
 isRSuccess :: RunResult a -> Bool
 isRSuccess (RSuccess _) = True
 isRSuccess _ = False
 
-gen2BytesStr :: Gen (BytesStr, BytesStr)
+gen2BytesStr :: H.Gen (BytesStr, BytesStr)
 gen2BytesStr = do
   x <- genBytesStr
   y <- genBytesStr
@@ -37,7 +42,7 @@ data BytesStr = MkBytesStr
   }
   deriving (Show)
 
-genBytesStr :: Gen BytesStr
+genBytesStr :: H.Gen BytesStr
 genBytesStr = do
   d <- Gen.integral (Range.linear 0 1_000_000_000)
   u <- Gen.integral (Range.linear 0 1_000_000_000)

--- a/test/spec/TypesSpec.hs
+++ b/test/spec/TypesSpec.hs
@@ -1,22 +1,24 @@
 {-# LANGUAGE GADTs #-}
 
-module PureCLISpec
-  ( spec_pureCLI,
+module TypesSpec
+  ( dslSpec,
   )
 where
 
 import Freer
-import Types
 import Test.Hspec
+import qualified Test.Tasty as T
+import qualified Test.Tasty.Hspec as TH
+import Types
 
-spec_pureCLI :: Spec
-spec_pureCLI = do
-  describe "PureCLISpec" $ do
-    it "Parse and run succeeds" $
+dslSpec :: IO [T.TestTree]
+dslSpec = TH.testSpecs $ do
+  describe "Types" $ do
+    it "DSL parse and run succeeds" $
       foldFreer interpretSuccess runCLI `shouldSatisfy` verifyCLI
-    it "Parse failure" $
+    it "DSL parse failure" $
       foldFreer interpretParseFail runCLI `shouldSatisfy` verifyParseFail
-    it "Cmd failure" $
+    it "DSL cmd failure" $
       foldFreer interpretCmdFail runCLI `shouldSatisfy` verifyCmdFail
 
 verifyCLI :: Identity () -> Bool


### PR DESCRIPTION
Removed auto discovery as manual gives better control over organizing and labeling tests